### PR TITLE
[HB-3311] - Create default pull request template to THB GitHub organization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Ticket(s)
 
-- [[T-###] - TICKET_SUMMARY_HERE](linktoticket)
+- [\[T-####\] TICKET_SUMMARY_HERE](linktoticket)
 
 ### Summary / Problem Statement
 - Please include a brief summary of the changes in this PR.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,21 @@
+### Ticket(s)
+
+- [T-### - TICKET_SUMMARY_HERE](linktoticket)
+
+### Summary / Problem Statement
+- Please include a brief summary of the changes in this PR.
+
+### Changes Made
+- Describe the changes made in this PR, including any major areas of impact.
+
+### Dependencies
+- [Related PRs here](linktopr)
+- REMOVE SECTION IF NOT APPLICABLE
+
+### Additional Information
+- Include any additional information or context that might be helpful for reviewers.
+- REMOVE SECTION IF NOT APPLICABLE
+
+### Testing Plan (screenshots, etc.)
+- Outline the steps to test and verify the changes.
+- REMOVE SECTION IF NOT APPLICABLE

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Ticket(s)
 
-- [T-### - TICKET_SUMMARY_HERE](linktoticket)
+- [[T-###] - TICKET_SUMMARY_HERE](linktoticket)
 
 ### Summary / Problem Statement
 - Please include a brief summary of the changes in this PR.


### PR DESCRIPTION
### Ticket(s)

- [\[HB-3311\] - Create default pull request template to THB GitHub organization](https://thehelperbees.atlassian.net/browse/HB-3311)

### Summary / Problem Statement
- Introduce a default pull request template across our GitHub organizations to improve clarity, consistency, and efficiency during the code review process.

### Changes Made
- Added a .github/PULL_REQUEST_TEMPLATE.md file with a lightweight structure for PR submissions.
- The template prompts authors to provide summaries, detail changes made, note any dependencies, add extra context if needed, and outline a basic testing plan.
- Designed the template to be flexible — sections can be modified or removed if not applicable.

### Additional Information
- The template is intended to reduce friction, not add overhead. It’s a starting point to keep communication smooth as we grow.
- Open to feedback and iterations based on how the team uses it in practice.

### Testing Plan (screenshots, etc.)
- Verified that the template automatically populates when creating a new pull request in a test repository.
- Reviewed the formatting for clarity and ease of editing.

[HB-3311]: https://thehelperbees.atlassian.net/browse/HB-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ